### PR TITLE
Add helper methods in RubyVM used for tests

### DIFF
--- a/mjit.h
+++ b/mjit.h
@@ -138,6 +138,8 @@ mjit_exec_slowpath(rb_execution_context_t *ec, const rb_iseq_t *iseq, struct rb_
     return Qundef;
 }
 
+static int inline_threshold = 2;
+
 // Try to execute the current iseq in ec.  Use JIT code if it is ready.
 // If it is not, add ISEQ to the compilation queue and return Qundef for MJIT.
 // YJIT compiles on the thread running the iseq.
@@ -157,7 +159,7 @@ mjit_exec(rb_execution_context_t *ec)
         body->total_calls++;
     }
 
-    if (body->total_calls == 2) {
+    if (body->total_calls == (unsigned long) inline_threshold) {
       const rb_callable_method_entry_t *cme;
 
       cme = rb_vm_frame_method_entry(ec->cfp);

--- a/vm.c
+++ b/vm.c
@@ -3489,6 +3489,20 @@ vm_enable_inlining(VALUE self)
     return RBOOL(true);
 }
 
+/*
+ *  call-seq:
+ *     RubyVM.inline_threshold = int
+ *
+ * It sets the number of method call as the inlining threshold.
+ * This API is used for testing purposes.
+ */
+static VALUE
+vm_inline_threshold_set(VALUE self, VALUE n)
+{
+    inline_threshold = NUM2INT(n);
+    return n;
+}
+
 void
 Init_VM(void)
 {
@@ -3514,6 +3528,7 @@ Init_VM(void)
     rb_define_singleton_method(rb_cRubyVM, "keep_script_lines", vm_keep_script_lines, 0);
     rb_define_singleton_method(rb_cRubyVM, "keep_script_lines=", vm_keep_script_lines_set, 1);
     rb_define_singleton_method(rb_cRubyVM, "enable_inlining!", vm_enable_inlining, 0);
+    rb_define_singleton_method(rb_cRubyVM, "inline_threshold=", vm_inline_threshold_set, 1);
 
 #if USE_DEBUG_COUNTER
     rb_define_singleton_method(rb_cRubyVM, "reset_debug_counters", rb_debug_counter_reset, 0);

--- a/vm.c
+++ b/vm.c
@@ -3475,6 +3475,20 @@ vm_keep_script_lines_set(VALUE self, VALUE flags)
     return flags;
 }
 
+/*
+ *  call-seq:
+ *     RubyVM.enable_inlining! -> true
+ *
+ * It turns on the experimenal inlining feature.
+ * This API is used for testing purposes.
+ */
+static VALUE
+vm_enable_inlining(VALUE self)
+{
+    mjit_call_p = true;
+    return RBOOL(true);
+}
+
 void
 Init_VM(void)
 {
@@ -3499,6 +3513,7 @@ Init_VM(void)
     rb_define_singleton_method(rb_cRubyVM, "stat", vm_stat, -1);
     rb_define_singleton_method(rb_cRubyVM, "keep_script_lines", vm_keep_script_lines, 0);
     rb_define_singleton_method(rb_cRubyVM, "keep_script_lines=", vm_keep_script_lines_set, 1);
+    rb_define_singleton_method(rb_cRubyVM, "enable_inlining!", vm_enable_inlining, 0);
 
 #if USE_DEBUG_COUNTER
     rb_define_singleton_method(rb_cRubyVM, "reset_debug_counters", rb_debug_counter_reset, 0);

--- a/vm.c
+++ b/vm.c
@@ -3491,6 +3491,20 @@ vm_enable_inlining(VALUE self)
 
 /*
  *  call-seq:
+ *     RubyVM.disable_inlining! -> false
+ *
+ * It turns off the experimenal inlining feature.
+ * This API is used for testing purposes.
+ */
+static VALUE
+vm_disable_inlining(VALUE self)
+{
+    mjit_call_p = false;
+    return RBOOL(false);
+}
+
+/*
+ *  call-seq:
  *     RubyVM.inline_threshold = int
  *
  * It sets the number of method call as the inlining threshold.
@@ -3528,6 +3542,7 @@ Init_VM(void)
     rb_define_singleton_method(rb_cRubyVM, "keep_script_lines", vm_keep_script_lines, 0);
     rb_define_singleton_method(rb_cRubyVM, "keep_script_lines=", vm_keep_script_lines_set, 1);
     rb_define_singleton_method(rb_cRubyVM, "enable_inlining!", vm_enable_inlining, 0);
+    rb_define_singleton_method(rb_cRubyVM, "disable_inlining!", vm_disable_inlining, 0);
     rb_define_singleton_method(rb_cRubyVM, "inline_threshold=", vm_inline_threshold_set, 1);
 
 #if USE_DEBUG_COUNTER


### PR DESCRIPTION
# Changes

* Add `enable_inlining!` and `inline_threshold=` as we discussed

# Notes 

The switch in flag for `enable_inlining!` only modifies `mjit_call_p`. Previously we talked about also modifying `mjit_enable_p` but I found that it was an argument passed into `vm_exec()` and not a global variable. However, just modifying `mjit_call_p` does the trick. 

I'm not sure where the `inline_threshold` global variable should go, so I stuck it right above the function that uses it. Sorry I'm new to C -- should the `inline_threshold` variable also be `unsigned int` type so I don't have to cast it from an int to do the comparision?   
