### PR TITLE
Set and get `self` as local variable

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -746,11 +746,10 @@ rb_vm_insn_null_translator(const void *addr)
 
 struct inline_context {
     rb_iseq_t * iseq;
-    unsigned int caller_locals;
+    unsigned int caller_local_table_size;
     LINK_ANCHOR *code_list_root;
     unsigned int depth;
     LABEL * leave_label;
-    unsigned int caller_local_size;
     unsigned int local_increase;
     st_table * labels;
 };
@@ -13289,15 +13288,14 @@ rb_inline_callee_iseqs(const rb_iseq_t * original_iseq)
     struct inline_context ctx;
     ctx.iseq = iseq; // Inlined iseq
 
-    // number of locals in the caller
-    ctx.caller_locals = original_iseq->body->local_table_size;
+    // Number of locals in the caller
+    ctx.caller_local_table_size = original_iseq->body->local_table_size;
 
     // Linked list for building the inlined method
     ctx.code_list_root = code_list_root;
 
     // depth
     ctx.depth = 0;
-    ctx.caller_local_size = original_iseq->body->local_table_size;
     ctx.labels = st_init_numtable();
 
     const rb_code_location_t *loc = &body->location.code_location;

--- a/compile.c
+++ b/compile.c
@@ -13201,6 +13201,10 @@ inline_iseqs(VALUE *code, size_t pos, iseq_value_itr_t * func, void *_ctx, rb_vm
             int idx = NUM2INT(OPERAND_AT(insn, 0)) + ctx->callee_local_table_size;
             insn = new_insn_body(iseq, &dummy_line_node, BIN(getlocal), 2, INT2FIX(idx), OPERAND_AT(insn, 1));
         }
+        if (ctx->depth > 0 && IS_INSN_ID(insn, putself)) {
+            insn = new_insn_body(iseq, &dummy_line_node, BIN(getlocal), 2, INT2FIX(ctx->self_index + VM_ENV_DATA_SIZE), INT2NUM(0));
+        }
+
         ADD_ELEM(code_list_root, (LINK_ELEMENT *)insn);
     }
 

--- a/compile.c
+++ b/compile.c
@@ -13323,7 +13323,7 @@ rb_inline_callee_iseqs(const rb_iseq_t * original_iseq)
     iseq->body->param.size = original_iseq->body->param.size;
     iseq->body->param.lead_num = original_iseq->body->param.lead_num;
 
-    unsigned int local_size = ctx.callee_local_table_size + ctx.caller_locals;
+    unsigned int local_size = ctx.callee_local_table_size + ctx.caller_local_table_size;
     fprintf(stderr, "original size: %d new size %d\n", original_iseq->body->local_table_size, local_size);
     ID *ids = (ID *)ALLOC_N(ID, local_size);
     MEMCPY(ids, original_iseq->body->local_table, ID, original_iseq->body->local_table_size);


### PR DESCRIPTION
# Changes 
- Set and get self as local variable
- Fix bug where local table for caller gets reused 
- Rename field in `ctx` 